### PR TITLE
[Feat] CouponInteractionView UI 작업

### DIFF
--- a/BirtherDay/Common/Components/BDButton.swift
+++ b/BirtherDay/Common/Components/BDButton.swift
@@ -1,8 +1,0 @@
-//
-//  BDButton.swift
-//  BirtherDay
-//
-//  Created by Rama on 5/28/25.
-//
-
-import Foundation

--- a/BirtherDay/Common/Components/BDButtonStyle.swift
+++ b/BirtherDay/Common/Components/BDButtonStyle.swift
@@ -1,0 +1,51 @@
+//
+//  BDButton.swift
+//  BirtherDay
+//
+//  Created by Rama on 5/28/25.
+//
+
+import SwiftUI
+
+// MARK: - Button Style
+enum BDButtonType {
+   case activate
+   case deactivate
+    
+   var backgroundColor: Color {
+       switch self {
+       case .activate:
+           return Color(red: 0.5, green: 0.31, blue: 0.85)
+       case .deactivate:
+           return Color(red: 0.9, green: 0.9, blue: 0.9)
+       }
+   }
+   
+   var textColor: Color {
+       switch self {
+       case .activate:
+           return Color.white
+       case .deactivate:
+           return Color(red: 0.6, green: 0.6, blue: 0.6)
+       }
+   }
+}
+
+struct BDButtonStyle: ButtonStyle {
+    let buttonType: BDButtonType
+    
+    init(buttonType: BDButtonType) {
+        self.buttonType = buttonType
+    }
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(buttonType.textColor)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(buttonType.backgroundColor)
+            .clipShape(Capsule())
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/BirtherDay/Common/Extension/Font+Extension.swift
+++ b/BirtherDay/Common/Extension/Font+Extension.swift
@@ -11,22 +11,50 @@ import SwiftUI
 
 extension Font {
     // Regular
+    /// Regular 14/150
     static let r1: Font = .custom("Pretendard-Regular", size: 14)      // 150%
+    
+    /// Regular 18/150
     static let r2: Font = .custom("Pretendard-Regular", size: 18)      // 150%
+    
+    /// Regular 12/150
     static let r3: Font = .custom("Pretendard-Regular", size: 20)      // 150%
     
+    /// Regular 12/150
+    static let r4: Font = .custom("Pretendard-Regular", size: 12)      // 150%
+    
+    
     // Medium
+    /// Medium 16/150
     static let m1: Font = .custom("Pretendard-Medium", size: 16)    // 150%
     
+    /// Medium 18/150
+    static let m2: Font = .custom("Pretendard-Medium", size: 18)    // 150%
+    
     // Semibold
+    /// SemiBold 16/150
     static let sb1: Font = .custom("Pretendard-Semibold", size: 16) // 150%
+    
+    /// SemiBold 18/150
     static let sb2: Font = .custom("Pretendard-Semibold", size: 18) // 150%
+    
+    /// SemiBold 20/150
     static let sb3: Font = .custom("Pretendard-Semibold", size: 20) // 150%
+    
+    /// SemiBold 22/150
     static let sb4: Font = .custom("Pretendard-Semibold", size: 22) // 150%
+    
+    /// SemiBold 24/150
     static let sb5: Font = .custom("Pretendard-Semibold", size: 24) // 130%
     
+    
     // Bold
+    /// Bold 14/150
     static let b1: Font = .custom("Pretendard-Bold", size: 14)      // 150%
+    
+    /// Bold 18/150
     static let b2: Font = .custom("Pretendard-Bold", size: 18)      // 150%
+    
+    /// Bold 24/130
     static let b3: Font = .custom("Pretendard-Bold", size: 24)      // 130%
 }

--- a/BirtherDay/Presentation/CreateCoupon/CouponTemplateView.swift
+++ b/BirtherDay/Presentation/CreateCoupon/CouponTemplateView.swift
@@ -157,49 +157,6 @@ struct TemplateButton: View {
     }
 }
 
-// MARK: - Button Style
-enum BDButtonType {
-   case activate
-   case deactivate
-    
-   var backgroundColor: Color {
-       switch self {
-       case .activate:
-           return Color(red: 0.5, green: 0.31, blue: 0.85)
-       case .deactivate:
-           return Color(red: 0.9, green: 0.9, blue: 0.9)
-       }
-   }
-   
-   var textColor: Color {
-       switch self {
-       case .activate:
-           return Color.white
-       case .deactivate:
-           return Color(red: 0.6, green: 0.6, blue: 0.6)
-       }
-   }
-}
-
-struct BDButtonStyle: ButtonStyle {
-    let buttonType: BDButtonType
-    
-    init(buttonType: BDButtonType) {
-        self.buttonType = buttonType
-    }
-    
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .foregroundColor(buttonType.textColor)
-            .frame(maxWidth: .infinity)
-            .frame(height: 56)
-            .background(buttonType.backgroundColor)
-            .clipShape(Capsule())
-            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
-            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
-    }
-}
-
 #Preview {
     CouponTemplateView(viewModel: CreateCouponViewModel())
         .environmentObject(BDNavigationPathManager())

--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -39,7 +39,7 @@ struct HomeView: View {
                         MyCouponView()
                     case .couponDetail:
                         Text("CouponDetailView")
-//                        CouponDetailView(viewModel: .init(coupon: .stub01)) // TODO: - remove stub
+                        CouponDetailView(viewModel: CouponDetailViewModel())
                     case .interaction:
                         CouponInteractionView()
                     case .interactionComplete:

--- a/BirtherDay/Presentation/MyCoupons/CouponDetailView.swift
+++ b/BirtherDay/Presentation/MyCoupons/CouponDetailView.swift
@@ -16,13 +16,13 @@ struct CouponDetailView: View {
         ScrollView {
             VStack(spacing: 0) {
                 mainCouponView()
-                dashedLineView(color: templateType.dashLineColor)
+                dashedLineView(color: templateType.dashLineColor, color2: templateType.basicColor)
                 subtitleView(subtitle: "📷 함께 첨부된 사진을 확인하세요!")
-                dashedLineView(color: Color.gray200)
+                dashedLineView(color: Color.gray200, color2: Color.white)
                 imageListView()
-                dashedLineView(color: Color.gray200)
+                dashedLineView(color: Color.gray200, color2: Color.white)
                 subtitleView(subtitle: "💌 함께 도착한 편지를 읽어보세요!")
-                dashedLineView(color: Color.gray200)
+                dashedLineView(color: Color.gray200, color2: Color.white)
                 letterView()
             }
             .padding(.horizontal, 27)
@@ -33,20 +33,31 @@ struct CouponDetailView: View {
     
     // 메인 쿠폰 뷰
     func mainCouponView()-> some View {
-        BDTemplateView(type: templateType)    // TODO: 모델 연결
+        BDTemplateView(type: templateType, isShownSubtitleView: false)    // TODO: 모델 연결
     }
     
     // 점선 뷰
-    func dashedLineView(color: Color)-> some View {
-        Path { path in
-            path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
-            path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 84, y: 0)) // 27*2 padding + 30 radius 고려
+    func dashedLineView(color: Color, color2: Color)-> some View {
+        ZStack {
+            // 쿠폰 경계에 있는 외곽선 지우는 선
+            Path { path in
+                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
+                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 84, y: 0)) // 27*2 padding + 30 radius 고려
+            }
+            .stroke(color2)
+            .frame(height: 1)
+            
+            // 점선
+            Path { path in
+                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
+                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 84, y: 0)) // 27*2 padding + 30 radius 고려
+            }
+            .stroke(
+                color,
+                style: StrokeStyle(lineWidth: 2, dash: [10])
+            )
+            .frame(height: 1)
         }
-        .stroke(
-            color,
-            style: StrokeStyle(lineWidth: 2, dash: [10])
-        )
-        .frame(height: 1)
     }
     
     // 서브 타이틀 뷰
@@ -81,5 +92,5 @@ struct CouponDetailView: View {
 }
 
 #Preview {
-//    CouponDetailView(viewModel: CouponDetailViewModel(coupon: .stub01))
+    CouponDetailView(viewModel: CouponDetailViewModel())
 }

--- a/BirtherDay/Presentation/MyCoupons/CouponDetailViewModel.swift
+++ b/BirtherDay/Presentation/MyCoupons/CouponDetailViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @Observable
 class CouponDetailViewModel {
-    var coupon: Coupon
+    var coupon: Coupon = .init(couponId: "", sender: .init(), template: .blue, couponTitle: "", letter: "", imageList: [], senderName: "", expireDate: Date(), thumbnail: .card1Back, isUsed: false, createdDate: Date())
     
     var expireDateString: String {
 //        guard let date = coupon.expireDate else { return "" } // Coupon 프로퍼티들에 옵셔널 처리했을 경우 사용
@@ -17,9 +17,9 @@ class CouponDetailViewModel {
         return DateFormatter.expiredDateFormatter.string(from: date) // yyyy.mm.dd
     }
     
-    init(coupon: Coupon) {
-        self.coupon = coupon
-    }
+//    init(coupon: Coupon) {
+//        self.coupon = coupon
+//    }
 }
 
 extension CouponDetailViewModel {

--- a/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
+++ b/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
@@ -9,13 +9,16 @@ import SwiftUI
 
 struct CouponInteractionView: View {
     
-    @State var distance: Float = 0.88    // TODO: - distance 0.00m 연결
+    @State var distance: Float = 0.58    // TODO: - distance 0.00m 연결
+    var minimuDetectedDistance: Float = 2.0
+    var screenHeight: CGFloat = UIScreen.main.bounds.height
     
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 Color.bgDark.ignoresSafeArea()
                 Color.mainPrimary.ignoresSafeArea()
+                    .frame(height: calDistanceToScreenHeight()) // distance에 따른 높이 조절
             }
             VStack(spacing: 30) {   // TODO: - 쿠폰 영역에 따른 dashed line 크기 수정하기
                 VStack {
@@ -45,9 +48,16 @@ struct CouponInteractionView: View {
                 
             
             Text("\(distance, specifier: "%.2f")m")
-                .foregroundStyle(distance == 0.0 ? Color.mainPrimary : Color.bgLight)
+                .foregroundStyle(distance == 2.0 ? Color.mainPrimary : Color.bgLight)
         }
         .font(.sb5)
+    }
+    
+    
+    // methods
+    /// 측정된 distance를 기반으로 배경색의 높이를 구하는 함수
+    func calDistanceToScreenHeight() -> CGFloat {
+        CGFloat(distance / minimuDetectedDistance) * screenHeight
     }
 }
 

--- a/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
+++ b/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
@@ -8,8 +8,46 @@
 import SwiftUI
 
 struct CouponInteractionView: View {
+    
+    @State var distance: Float = 0.88    // TODO: - distance 0.00m 연결
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            VStack(spacing: 0) {
+                Color.bgDark.ignoresSafeArea()
+                Color.mainPrimary.ignoresSafeArea()
+            }
+            VStack(spacing: 30) {   // TODO: - 쿠폰 영역에 따른 dashed line 크기 수정하기
+                VStack {
+                    Text("서로의 휴대폰을\n조금 더 가까이 이동시켜주세요!")
+                        .font(.sb5)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(Color.bgLight)
+                    
+                    Text("0.5m 이내로 가까워졌을 때 사용이 가능해요.")
+                        .font(.m1)
+                        .foregroundStyle(Color.gray100)
+                }
+                BDTemplateView(type: .blue, isShownSubtitleView: true)
+                    .scaleEffect(204/320)
+                    .rotationEffect(.degrees(7.86))
+                    
+                distanceView()
+            }
+                
+        }
+    }
+    
+    func distanceView()-> some View {
+        HStack {
+            Text("우리사이 거리")
+                .foregroundStyle(Color.bgLight)
+                
+            
+            Text("\(distance, specifier: "%.2f")m")
+                .foregroundStyle(distance == 0.0 ? Color.mainPrimary : Color.bgLight)
+        }
+        .font(.sb5)
     }
 }
 

--- a/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
+++ b/BirtherDay/Presentation/MyCoupons/CouponInteractionView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CouponInteractionView: View {
     
-    @State var distance: Float = 0.58    // TODO: - distance 0.00m 연결
+    @State var distance: Float = 1.2    // TODO: - distance 0.00m 연결
     var minimuDetectedDistance: Float = 2.0
     var screenHeight: CGFloat = UIScreen.main.bounds.height
     
@@ -57,7 +57,7 @@ struct CouponInteractionView: View {
     // methods
     /// 측정된 distance를 기반으로 배경색의 높이를 구하는 함수
     func calDistanceToScreenHeight() -> CGFloat {
-        CGFloat(distance / minimuDetectedDistance) * screenHeight
+        screenHeight - CGFloat(distance / minimuDetectedDistance) * screenHeight
     }
 }
 

--- a/BirtherDay/Presentation/MyCoupons/Template/BDTemplateView.swift
+++ b/BirtherDay/Presentation/MyCoupons/Template/BDTemplateView.swift
@@ -12,7 +12,8 @@ struct BDTemplateView: View {
     let type: CouponTemplate
     let sender: String = "주니"
     let date: String = "2025.06.01"
-    var isShownSubtitleView = true      // 하단 쿠폰을 보여줄지 정하는 프로퍼티
+    
+    var isShownSubtitleView = true           /// 하단 쿠폰을 보여줄지 정하는 프로퍼티
     var title = "나랑 저녁에 애슐리 먹으러 가자!"                      // 쿠폰 제목
     var subtitle = "쿠폰을 사용 중이에요👏"
     
@@ -20,7 +21,7 @@ struct BDTemplateView: View {
         VStack(spacing: 0) {
             mainCouponView()
             if isShownSubtitleView {
-                dashedLineView(color: type.dashLineColor, color2: type.basicColor)
+                dashedLineView(basicColor: type.basicColor, dashLineColor: type.dashLineColor)
                 subtitleView(subtitle: subtitle)
             }
         }
@@ -106,15 +107,15 @@ struct BDTemplateView: View {
             .frame(maxWidth: .infinity, alignment: .center)
     }
     
-    /// 점선 뷰
-    func dashedLineView(color: Color, color2: Color)-> some View {
+    /// 점선 뷰 - basicColor: 쿠폰 배경색, dashLineColor: 점선색
+    func dashedLineView(basicColor: Color, dashLineColor: Color)-> some View {
         ZStack {
             // 쿠폰 경계에 있는 외곽선 지우는 선
             Path { path in
                 path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
                 path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
             }
-            .stroke(color2)
+            .stroke(basicColor)
             .frame(height: 1)
             
             // 점선
@@ -123,7 +124,7 @@ struct BDTemplateView: View {
                 path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
             }
             .stroke(
-                color,
+                dashLineColor,
                 style: StrokeStyle(lineWidth: 2, dash: [10])
             )
             .frame(height: 1)

--- a/BirtherDay/Presentation/MyCoupons/Template/BDTemplateView.swift
+++ b/BirtherDay/Presentation/MyCoupons/Template/BDTemplateView.swift
@@ -12,70 +12,134 @@ struct BDTemplateView: View {
     let type: CouponTemplate
     let sender: String = "주니"
     let date: String = "2025.06.01"
+    var isShownSubtitleView = true      // 하단 쿠폰을 보여줄지 정하는 프로퍼티
+    var title = "나랑 저녁에 애슐리 먹으러 가자!"                      // 쿠폰 제목
+    var subtitle = "쿠폰을 사용 중이에요👏"
     
     var body: some View {
-        VStack(spacing: 30) {
-            VStack(alignment: .leading) {
-                Text("From. \(sender)")
-                    .font(.sb3)
-                    .foregroundStyle(Color.textTitle)
-                Text("\(date)까지")
-                    .font(.r3)
+        VStack(spacing: 0) {
+            mainCouponView()
+            if isShownSubtitleView {
+                dashedLineView(color: type.dashLineColor, color2: type.basicColor)
+                subtitleView(subtitle: subtitle)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .aspectRatio(isShownSubtitleView ? 32/53 : 32/43, contentMode: .fit)        // 하단 subtitle뷰 여부에 따른 쿠폰 가로세로 비율 고정
+    }
+    
+    /// 메인 쿠폰 뷰
+    func mainCouponView()-> some View {
+        VStack(spacing: 30) {
+            senderDateView()
             
-            Spacer(minLength: 0)
+            Spacer()
             
             // TODO: - Image 연결
             Rectangle()
-                .frame(width: 150, height: 150)
+                .frame(width: 200, height: 200)
             
-            Spacer(minLength: 0)
+            Spacer()
             
-            // TODO: - content 연결
-            Text("함께 만나서 사용할 쿠폰 입력해주세요!")
-                .frame(maxWidth: .infinity)
-                .font(.sb4)
-                .foregroundStyle(Color.textTitle)
-                .multilineTextAlignment(.center)
-                .lineLimit(3)
+            titleView()
         }
-        .frame(minHeight: 430)
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 17)
-        .padding(.top, 31)
-        .padding(.bottom, 35)
+
+        .padding(.vertical, 35)
+        .padding(.horizontal, 27)
+        .frame(minHeight: 320)
         .background {
             // 배경에 사용되는 circle + blur
-            VStack(spacing: 0) {
-                HStack {
-                    Circle().foregroundStyle(type.backgroundPointColor[0].opacity(0.8))
-                        .blur(radius: 75)
-                        .frame(width: 123, height: 123)
-                    Spacer()
-                }
-                
-                Spacer()
-                    .frame(height: 37)
-                HStack {
-                    Circle().foregroundStyle(type.backgroundPointColor[1].opacity(0.5))
-                        .blur(radius: 75)
-                        .frame(width: 204, height: 204)
-                        .padding(.leading, -18)
-                    Spacer()
-                }
-                HStack {
-                    Spacer()
-                    Circle().foregroundStyle(type.backgroundPointColor[2].opacity(0.5))
-                        .blur(radius: 75)
-                        .frame(width: 204, height: 204)
-                        .padding(.trailing, -40)
-                }
-            }
+            bluredCircleView()
         }
         .background(type.backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: 30))
         .overlay(RoundedRectangle(cornerRadius: 30).stroke(type.strokeColor, lineWidth: 1))
+    }
+    
+    /// 전송자 및 만료날짜
+    func senderDateView()-> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("From. \(sender)")
+                .font(.sb3)
+                .foregroundStyle(Color.textTitle)
+            Text("\(date)까지")
+                .font(.r3)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    
+    /// 쿠폰 배경에 사용되는 블러처리된 원형 뷰
+    func bluredCircleView()-> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Circle().foregroundStyle(type.backgroundPointColor[0].opacity(0.8))
+                    .blur(radius: 75)
+                    .frame(width: 123, height: 123)
+                Spacer()
+            }
+            
+            Spacer()
+                .frame(height: 37)
+            HStack {
+                Circle().foregroundStyle(type.backgroundPointColor[1].opacity(0.5))
+                    .blur(radius: 75)
+                    .frame(width: 204, height: 204)
+                    .padding(.leading, -18)
+                Spacer()
+            }
+            HStack {
+                Spacer()
+                Circle().foregroundStyle(type.backgroundPointColor[2].opacity(0.5))
+                    .blur(radius: 75)
+                    .frame(width: 204, height: 204)
+                    .padding(.trailing, -40)
+            }
+        }
+    }
+    
+    func titleView()-> some View {
+        Text(title)
+            .frame(maxWidth: .infinity)
+            .font(.sb4)
+            .foregroundStyle(Color.textTitle)
+            .multilineTextAlignment(.center)
+            .lineLimit(3)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+    
+    /// 점선 뷰
+    func dashedLineView(color: Color, color2: Color)-> some View {
+        ZStack {
+            // 쿠폰 경계에 있는 외곽선 지우는 선
+            Path { path in
+                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
+                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
+            }
+            .stroke(color2)
+            .frame(height: 1)
+            
+            // 점선
+            Path { path in
+                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
+                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
+            }
+            .stroke(
+                color,
+                style: StrokeStyle(lineWidth: 2, dash: [10])
+            )
+            .frame(height: 1)
+        }
+    }
+    
+    /// 서브 타이틀 뷰
+    func subtitleView(subtitle: String) -> some View {
+        Text(subtitle)
+            .font(.sb2)
+            .foregroundStyle(Color.textTitle)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 38)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 30))
+    
     }
 }
 


### PR DESCRIPTION
## 👀 **작업한 내용, 스크린샷**

# CouponInteractionView View 추가
<img width="340" alt="Screenshot 2025-06-03 at 18 52 06" src="https://github.com/user-attachments/assets/3eb174f4-4a1a-4a4c-ab23-0d15b6a01b0a" />
쿠폰 사용하기 눌렀을 때 나오는 View 작업했습니다.
중간에 사용자가 고른 내용을 담은 쿠폰을 가져와야 해서 BDTemplateView에 변동사항이 생겼습니다.

# BDTemplateView 수정
## subtitle View
`isShownSubtitleView` 프로퍼티가 생겼습니다.


## 사용방법
<img width="329" alt="Screenshot 2025-06-03 at 19 04 38" src="https://github.com/user-attachments/assets/e327d4a9-6b59-413b-9622-42ea2ee09c3b" />

``` swift
BDTemplateView(type: .blue, isShownSubtitleView: true)
```

<img width="321" alt="Screenshot 2025-06-03 at 19 04 30" src="https://github.com/user-attachments/assets/1c4d38f4-e6b1-4305-8803-ee271ab48657" />

``` swift
BDTemplateView(type: .blue, isShownSubtitleView: false)
```
하단에 타이틀을 띄우고 싶으면 true로, 설정하심 됩니더

## dashedLine() 함수 수정
쿠폰의 절취선이랑 쿠폰 외곽선이 겹치는 부분을 가리기 위해서 dashedLine() 함수를 수정했습니다.
```swift
func dashedLineView(basicColor: Color, dashLineColor: Color)-> some View {
        ZStack {
            // 쿠폰 경계에 있는 외곽선 지우는 선
            Path { path in
                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
            }
            .stroke(basicColor)
            .frame(height: 1)
            
            // 점선
            Path { path in
                path.move(to: CGPoint(x: 30, y: 0)) // TODO: create radius & padding property
                path.addLine(to: CGPoint(x: UIScreen.main.bounds.width - 30, y: 0)) // 27*2 padding + 30 radius 고려
            }
            .stroke(
                dashLineColor,
                style: StrokeStyle(lineWidth: 2, dash: [10])
            )
            .frame(height: 1)
        }
    }
```
쿠폰 배경색으로 외곽선을 덮고 그 위에 점선을 얹는 방식입니더
color: 점선 색
color2: 배경 색


## 사용 방법
```swift
dashedLineView(basicColor: type.basicColor, dashLineColor: type.dashLineColor)
dashedLineView(basicColor: Color.orange, dashLineColor: Color.white)
```
점선뷰는 컴포넌트로 아직 안 빼뒀는데 필요하다면 빼두겠습니다!

### 수정 전
<img width="302" alt="Screenshot 2025-06-03 at 19 07 48" src="https://github.com/user-attachments/assets/3bd46ea5-6181-404f-b20d-80a5a983f4f7" />

### 수정 후
<img width="300" alt="Screenshot 2025-06-03 at 19 07 33" src="https://github.com/user-attachments/assets/b2606494-ae2e-4886-87f0-7efc97adcd74" />

## Font r4 추가 및 주석
<img width="553" alt="Screenshot 2025-06-03 at 19 13 53" src="https://github.com/user-attachments/assets/3068851b-240f-4409-820d-585199291c35" />
폰트 고를 때 정보까지 볼 수 있도록 주석 달앗습니다 !

## CouponDetailViewModel 초기화 방식 수정
stub이 없어지면서 해당 뷰모델 초기화가 많이 귀찮았는데 일단 뷰모델 내부에 값을 넣어서 ㆅ
뷰모델만 띨롱 선언하셔도 됩니다
```swift
CouponDetailView(viewModel: CouponDetailViewModel())
```
