### PR TITLE
[Feat] HomeView UI, Components 작업

### DIFF
--- a/BirtherDay/Common/Components/BDMiniCoupon.swift
+++ b/BirtherDay/Common/Components/BDMiniCoupon.swift
@@ -8,29 +8,31 @@
 import SwiftUI
 
 struct BDMiniCoupon: View {
+    let coupon: Coupon
+    
     var body: some View {
         VStack(spacing: 0) {
             couponMainView()
             couponInfoView()
         }
+        .foregroundStyle(coupon.template.miniCouponBackgroundColor)
     }
     
     // MARK: - Functions
     /// 메인 쿠폰
     func couponMainView()-> some View {
-        let expireDay: String = "999"
-        
         return ZStack {
             RoundedRectangle(cornerRadius: 15)
-                .fill(Color.mainViolet100)
             
             VStack(alignment: .center, spacing: 0) {
                 HStack {
+                    
                     Spacer()
                     
-                    Text("D - \(expireDay)")
-                    // TODO: - .r3로 수줭
-                        .font(.r1)
+                    let daysLeft = Calendar.current.dateComponents([.day], from: Date(), to: coupon.expireDate).day ?? 0
+                    
+                    Text("D - \(max(0, daysLeft))")
+                        .font(.r4)
                         .foregroundStyle(Color.mainPrimary)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -46,14 +48,11 @@ struct BDMiniCoupon: View {
                 
                 dashedLineView(color: Color.mainViolet300)
             }
-            
-            Image("Card1Box")
+            coupon.template.miniCouponImage
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 90, height: 90)
                 .clipped()
-                //.padding(.horizontal, 35)
-
         }
         .frame(width: 165, height: 157)
     }
@@ -80,25 +79,20 @@ struct BDMiniCoupon: View {
                 style: StrokeStyle(lineWidth: 2, dash: [8, 6])
             )
             .frame(height: 1)
-            
-            
         }
     }
     
     /// 쿠폰 정보
     func couponInfoView()-> some View {
-        let couponTitle: String = "애슐리 디너\n1회 이용권"
-        let sender: String = "주니"
         
         return ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: 15)
-                .fill(Color.mainViolet100)
             VStack(alignment: .leading, spacing: 4) {
-                Text("\(couponTitle)")
+                Text("\(coupon.couponTitle)")
                     .font(.sb1)
                     .foregroundStyle(Color.textTitle)
                 
-                Text("From. \(sender)")
+                Text("From. \(coupon.senderName)")
                     .font(.r1)
                     .foregroundStyle(Color.mainPrimary)
             }
@@ -110,5 +104,18 @@ struct BDMiniCoupon: View {
 
 // (traits: .sizeThatFitsLayout)
 #Preview {
-    BDMiniCoupon()
+    BDMiniCoupon(coupon: Coupon(
+        couponId: "sample-id",
+        sender: UUID(),
+        receiver: nil,
+        template: .blue,
+        couponTitle: "애슐리 디너\n1회 이용권",
+        letter: "축하해!",
+        imageList: [],
+        senderName: "주니",
+        expireDate: Date().addingTimeInterval(86400 * 60),
+        thumbnail: UIImage(),
+        isUsed: false,
+        createdDate: Date()
+    ))
 }

--- a/BirtherDay/Common/Components/BDMiniCoupon.swift
+++ b/BirtherDay/Common/Components/BDMiniCoupon.swift
@@ -18,7 +18,7 @@ struct BDMiniCoupon: View {
         .foregroundStyle(coupon.template.miniCouponBackgroundColor)
     }
     
-    // MARK: - Functions
+    // MARK: - Views
     /// 메인 쿠폰
     func couponMainView()-> some View {
         return ZStack {
@@ -36,7 +36,9 @@ struct BDMiniCoupon: View {
                         .foregroundStyle(Color.mainPrimary)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .cornerRadius(100)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: 100)
+                        )
                         .overlay(
                             RoundedRectangle(cornerRadius: 100)
                                 .stroke(Color.mainPrimary, lineWidth: 0.5)

--- a/BirtherDay/Presentation/Home/BDMiniCoupon.swift
+++ b/BirtherDay/Presentation/Home/BDMiniCoupon.swift
@@ -1,0 +1,114 @@
+//
+//  BDMiniCoupon.swift
+//  BirtherDay
+//
+//  Created by 길지훈 on 6/3/25.
+//
+
+import SwiftUI
+
+struct BDMiniCoupon: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            couponMainView()
+            couponInfoView()
+        }
+    }
+    
+    // MARK: - Functions
+    /// 메인 쿠폰
+    func couponMainView()-> some View {
+        let expireDay: String = "999"
+        
+        return ZStack {
+            RoundedRectangle(cornerRadius: 15)
+                .fill(Color.mainViolet100)
+            
+            VStack(alignment: .center, spacing: 0) {
+                HStack {
+                    Spacer()
+                    
+                    Text("D - \(expireDay)")
+                    // TODO: - .r3로 수줭
+                        .font(.r1)
+                        .foregroundStyle(Color.mainPrimary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .cornerRadius(100)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 100)
+                                .stroke(Color.mainPrimary, lineWidth: 0.5)
+                        )
+                        .padding(.top, 10)
+                        .padding(.trailing, 9)
+                }
+                Spacer()
+                
+                dashedLineView(color: Color.mainViolet300)
+            }
+            
+            Image("Card1Box")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 90, height: 90)
+                .clipped()
+                //.padding(.horizontal, 35)
+
+        }
+        .frame(width: 165, height: 157)
+    }
+    
+    /// 점선
+    func dashedLineView(color: Color)-> some View {
+        ZStack {
+            Path { path in
+                path.move(to: CGPoint(x: 15, y: 0))
+                path.addLine(to: CGPoint(x: 150, y: 0))
+            }
+            .stroke(
+                Color.mainViolet100
+            )
+            .frame(height: 1)
+            
+            
+            Path { path in
+                path.move(to: CGPoint(x: 15, y: 0))
+                path.addLine(to: CGPoint(x: 150, y: 0))
+            }
+            .stroke(
+                color,
+                style: StrokeStyle(lineWidth: 2, dash: [8, 6])
+            )
+            .frame(height: 1)
+            
+            
+        }
+    }
+    
+    /// 쿠폰 정보
+    func couponInfoView()-> some View {
+        let couponTitle: String = "애슐리 디너\n1회 이용권"
+        let sender: String = "주니"
+        
+        return ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 15)
+                .fill(Color.mainViolet100)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(couponTitle)")
+                    .font(.sb1)
+                    .foregroundStyle(Color.textTitle)
+                
+                Text("From. \(sender)")
+                    .font(.r1)
+                    .foregroundStyle(Color.mainPrimary)
+            }
+            .padding(.horizontal, 16)
+        }
+        .frame(width: 164, height: 113)
+    }
+}
+
+// (traits: .sizeThatFitsLayout)
+#Preview {
+    BDMiniCoupon()
+}

--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -5,22 +5,21 @@
 //  Created by Rama on 5/28/25.
 //
 
-/// CouponTemplateView -> CouponInfoView -> CouponLetterView
-
 import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject var navPathManager: BDNavigationPathManager
     @StateObject private var couponViewModel = CreateCouponViewModel()
-    var homeViewModel = HomeViewModel()
+    private var homeViewModel = HomeViewModel()
     
     var body: some View {
         NavigationStack(path: $navPathManager.appPaths) {
-            ScrollView(showsIndicators: false) {
+            ScrollView {
                 VStack(spacing: 16) {
                     homeHeaderView(text: "자~ 로고들어갑니다 ^^")
-                    createCouponCTAView()
-                    couponShortcutView()
+                    createCouponCTACardView()
+                    homeHeaderView(text: "주고 받은 쿠폰을 확인해보세요!")
+                    couponBoxSelectorView()
                     homeDivider()
                     homeHeaderView(text: "아직 미사용 된 쿠폰이 남아있어요")
                     unusedCouponListView()
@@ -59,13 +58,13 @@ struct HomeView: View {
                         }
                     }
                 }
-            }
+            }.scrollIndicators(.hidden)
         }
     }
     
-    // MARK: - Functions
+    // MARK: - Views
     ///  쿠폰 만들러 가기
-    func createCouponCTAView() -> some View {
+    func createCouponCTACardView() -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 30)
                 .fill(Color.mainViolet100)
@@ -96,54 +95,34 @@ struct HomeView: View {
     }
     
     /// 보관함 가기 형제
-    func couponShortcutView() -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("주고 받은 쿠폰을 확인해보세요!")
-                    .font(.sb2)
-                Spacer()
-            }
-            .padding(.leading, 16)
-            .padding(.top, 8)
-            
-            HStack(spacing: 0) {
-                couponShortcutCardView("선물 받은")
-                couponShortcutCardView("내가 보낸")
-                
-            }
+    func couponBoxSelectorView() -> some View {
+        HStack(spacing: 16) {
+            couponBoxCardView("선물 받은")
+            couponBoxCardView("내가 보낸")
         }
     }
     
     /// 개별 보관함 가기
-    func couponShortcutCardView(_ tab: String) -> some View {
+    func couponBoxCardView(_ tab: String) -> some View {
         Button(action: {
             navPathManager.pushCreatePath(.selectTemplate)
         }) {
             HStack(alignment: .center, spacing: 8) {
-                if tab == "선물 받은" {
-                    Rectangle()
-                        .frame(width: 38, height: 38)
-                    Text("선물 받은\n쿠폰")
-                        .multilineTextAlignment(.leading)
-                        .font(.sb1)
-                        .foregroundStyle(Color.textTitle)
-                } else {
-                    Rectangle()
-                        .frame(width: 38, height: 38)
-                    Text("내가 보낸\n쿠폰")
-                        .multilineTextAlignment(.leading)
-                        .font(.sb1)
-                        .foregroundStyle(Color.textTitle)
-                }
+                Rectangle()
+                    .frame(width: 38, height: 38)
+                Text(tab == "선물 받은" ? "선물 받은\n쿠폰" : "내가 보낸\n쿠폰")
+                    .multilineTextAlignment(.leading)
+                    .font(.sb1)
+                    .foregroundStyle(Color.textTitle)
             }
             .padding(.trailing, 8)
             .padding(20)
         }
         .background(Color.gray100)
-        .cornerRadius(20)
-        .padding(8)
-        .padding(.top, 8)
-        .padding(.bottom, -2)
+        .clipShape(
+            RoundedRectangle(cornerRadius: 20)
+        )
+        .padding(.bottom, 6)
     }
     
     /// 구분선
@@ -167,7 +146,7 @@ struct HomeView: View {
     
     /// 미사용 쿠폰 리스트
     func unusedCouponListView() -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        ScrollView(.horizontal) {
             HStack(alignment: .center, spacing: 8) {
                 
                 // TODO: - 일정 갯수 이상 나오면, 더보기 카드(보관함)
@@ -176,7 +155,7 @@ struct HomeView: View {
                 }
             }
             .padding(.horizontal, 16)
-        }
+        }.scrollIndicators(.hidden)
     }
 }
 

--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -5,6 +5,8 @@
 //  Created by Rama on 5/28/25.
 //
 
+/// CouponTemplateView -> CouponInfoView -> CouponLetterView
+
 import SwiftUI
 
 struct HomeView: View {
@@ -13,87 +15,168 @@ struct HomeView: View {
     
     var body: some View {
         NavigationStack(path: $navPathManager.appPaths) {
-            VStack {
-                HomeFirstView(viewModel: couponViewModel)
-                HomeSecondView()
-                HomeThirdView()
-            }
-            .navigationDestination(for: BDAppPath.self) { path in
-                switch path {
-                case .create(let createPath):
-                    switch createPath {
-                    case .selectTemplate:
-                        CouponTemplateView(viewModel: couponViewModel)
-                    case .couponInfo:
-                        CouponInfoView(viewModel: couponViewModel)
-                    case .couponLetter:
-                        CouponLetterView(viewModel: couponViewModel)
-                    case .couponPicture:
-                        CouponPhotoView()
-                    case .couponComplete:
-                        CouponCompleteView()
-                    }
-                case .myCoupon(let myPath):
-                    switch myPath {
-                    case .couponInventory:
-                        MyCouponView()
-                    case .couponDetail:
-                        Text("CouponDetailView")
-                        CouponDetailView(viewModel: CouponDetailViewModel())
-                    case .interaction:
-                        CouponInteractionView()
-                    case .interactionComplete:
-                        InteractionCompleteView()
-                    }
-                case .test(let testPath):
-                    switch testPath {
-                    case .test:
-                        TestView()
+            ScrollView {
+                VStack(spacing: 16) {
+                    HomeHeaderView(text: "자~ 로고들어갑니다")
+                    CreateCouponCTAView()
+                    CouponShortcutView()
+                    HomeDivider()
+                    HomeHeaderView(text: "아직 미사용 된 쿠폰이 남아있어요")
+                    UnusedCouponListView()
+                }
+                .navigationDestination(for: BDAppPath.self) { path in
+                    switch path {
+                    case .create(let createPath):
+                        switch createPath {
+                        case .selectTemplate:
+                            CouponTemplateView(viewModel: couponViewModel)
+                        case .couponInfo:
+                            CouponInfoView(viewModel: couponViewModel)
+                        case .couponLetter:
+                            CouponLetterView(viewModel: couponViewModel)
+                        case .couponPicture:
+                            CouponPhotoView()
+                        case .couponComplete:
+                            CouponCompleteView()
+                        }
+                    case .myCoupon(let myPath):
+                        switch myPath {
+                        case .couponInventory:
+                            MyCouponView()
+                        case .couponDetail:
+                            Text("CouponDetailView")
+                            //                        CouponDetailView(viewModel: .init(coupon: .stub01)) // TODO: - remove stub
+                        case .interaction:
+                            CouponInteractionView()
+                        case .interactionComplete:
+                            InteractionCompleteView()
+                        }
+                    case .test(let testPath):
+                        switch testPath {
+                        case .test:
+                            TestView()
+                        }
                     }
                 }
             }
         }
     }
-}
-
-///  쿠폰 만들러 가기 뷰에 해당
-struct HomeFirstView: View {
-    @EnvironmentObject var navPathManager: BDNavigationPathManager
-    let viewModel: CreateCouponViewModel
     
-    var body: some View {
+    // MARK: - Functions
+    
+    ///  쿠폰 만들러 가기
+    func CreateCouponCTAView() -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 30)
+                .fill(Color.mainViolet100)
+            
+            VStack(alignment: .center, spacing: 20) {
+                Text("나만의 특별한 쿠폰으로\n생일을 축하해볼까요?")
+                    .lineSpacing(8)
+                    .font(.b2)
+                    .multilineTextAlignment(.center)
+                
+                // TODO: - Image 연결
+                Rectangle()
+                    .frame(width: 120, height: 120)
+                
+                Button(action: {
+                    navPathManager.pushCreatePath(.selectTemplate)
+                }) {
+                    Text("쿠폰 만들러 가기")
+                        .font(.sb1)
+                }
+                .buttonStyle(BDButtonStyle(buttonType: .activate))
+                //.padding(.horizontal, 16)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 20)
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    /// 보관함가기 형제
+    func CouponShortcutView() -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("주고 받은 쿠폰을 확인해보세요!")
+                    .font(.sb2)
+                Spacer()
+            }
+            .padding(.leading, 16)
+            .padding(.top, 8)
+            
+            HStack(spacing: 0) {
+                CouponShortcutCardView("선물 받은")
+                CouponShortcutCardView("내가 보낸")
+                    
+            }
+        }
+    }
+    
+    /// 개별 보관함 가기
+    func CouponShortcutCardView(_ tab: String) -> some View {
         Button(action: {
-            // 새로운 쿠폰 생성 시작할 때 데이터 초기화
-            viewModel.resetCouponCreation()
             navPathManager.pushCreatePath(.selectTemplate)
         }) {
-            Text("Move To CreateCoupon")
+            HStack(alignment: .center, spacing: 8) {
+                if tab == "선물 받은" {
+                    Rectangle()
+                        .frame(width: 38, height: 38)
+                    Text("선물 받은\n쿠폰")
+                        .multilineTextAlignment(.leading)
+                        .font(.sb1)
+                        .foregroundStyle(Color.textTitle)
+                } else {
+                    Rectangle()
+                        .frame(width: 38, height: 38)
+                    Text("내가 보낸\n쿠폰")
+                        .multilineTextAlignment(.leading)
+                        .font(.sb1)
+                        .foregroundStyle(Color.textTitle)
+                }
+            }
+            .padding(.trailing, 8)
+            .padding(20)
         }
+        .background(Color.gray100)
+        .cornerRadius(20)
+        .padding(8)
+        .padding(.top, 8)
+        .padding(.bottom, -2)
     }
-}
-
-///  선물 받은 쿠폰, 내가 보낸 쿠폰에 해당
-struct HomeSecondView: View {
-    @EnvironmentObject var navPathManager: BDNavigationPathManager
-
-    var body: some View {
-        Button(action: {
-            navPathManager.pushMyCouponPath(.couponInventory)
-        }) {
-            Text("Move To MyCoupon")
-        }
-    }
-}
-
-///  테스트 뷰
-struct HomeThirdView: View {
-    @EnvironmentObject var navPathManager: BDNavigationPathManager
     
-    var body: some View {
-        Button(action: {
-            navPathManager.pushTestPath(.test)
-        }) {
-            Text("Move To TestView")
+    /// 구분선
+    func HomeDivider() -> some View {
+        Divider().frame(height: 8).overlay(Color.gray100)
+    }
+    
+    /// 헤더
+    func HomeHeaderView(text: String) -> some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text(text)
+                    .font(.sb2)
+                    .foregroundStyle(Color.textTitle)
+                Spacer()
+            }
+            .padding(.leading, 16)
+            .padding(.top, 8)
         }
     }
+    
+    /// 미사용 쿠폰 리스트
+    func UnusedCouponListView() -> some View {
+        // TODO: - Hstack 리스트 구현
+        Rectangle()
+            .foregroundStyle(Color.mainViolet100)
+            .padding(.horizontal, 16)
+            .frame(minHeight: 270)
+    }
+}
+
+
+#Preview {
+    HomeView()
+        .environmentObject(BDNavigationPathManager())
 }

--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -12,17 +12,18 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject var navPathManager: BDNavigationPathManager
     @StateObject private var couponViewModel = CreateCouponViewModel()
+    var homeViewModel = HomeViewModel()
     
     var body: some View {
         NavigationStack(path: $navPathManager.appPaths) {
             ScrollView {
                 VStack(spacing: 16) {
-                    HomeHeaderView(text: "자~ 로고들어갑니다")
-                    CreateCouponCTAView()
-                    CouponShortcutView()
-                    HomeDivider()
-                    HomeHeaderView(text: "아직 미사용 된 쿠폰이 남아있어요")
-                    UnusedCouponListView()
+                    homeHeaderView(text: "자~ 로고들어갑니다")
+                    createCouponCTAView()
+                    couponShortcutView()
+                    homeDivider()
+                    homeHeaderView(text: "아직 미사용 된 쿠폰이 남아있어요")
+                    unusedCouponListView()
                 }
                 .navigationDestination(for: BDAppPath.self) { path in
                     switch path {
@@ -63,9 +64,8 @@ struct HomeView: View {
     }
     
     // MARK: - Functions
-    
     ///  쿠폰 만들러 가기
-    func CreateCouponCTAView() -> some View {
+    func createCouponCTAView() -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 30)
                 .fill(Color.mainViolet100)
@@ -95,8 +95,8 @@ struct HomeView: View {
         .padding(.horizontal, 16)
     }
     
-    /// 보관함가기 형제
-    func CouponShortcutView() -> some View {
+    /// 보관함 가기 형제
+    func couponShortcutView() -> some View {
         VStack(spacing: 0) {
             HStack {
                 Text("주고 받은 쿠폰을 확인해보세요!")
@@ -107,15 +107,15 @@ struct HomeView: View {
             .padding(.top, 8)
             
             HStack(spacing: 0) {
-                CouponShortcutCardView("선물 받은")
-                CouponShortcutCardView("내가 보낸")
-                    
+                couponShortcutCardView("선물 받은")
+                couponShortcutCardView("내가 보낸")
+                
             }
         }
     }
     
     /// 개별 보관함 가기
-    func CouponShortcutCardView(_ tab: String) -> some View {
+    func couponShortcutCardView(_ tab: String) -> some View {
         Button(action: {
             navPathManager.pushCreatePath(.selectTemplate)
         }) {
@@ -147,12 +147,12 @@ struct HomeView: View {
     }
     
     /// 구분선
-    func HomeDivider() -> some View {
+    func homeDivider() -> some View {
         Divider().frame(height: 8).overlay(Color.gray100)
     }
     
     /// 헤더
-    func HomeHeaderView(text: String) -> some View {
+    func homeHeaderView(text: String) -> some View {
         VStack(spacing: 16) {
             HStack {
                 Text(text)
@@ -166,12 +166,16 @@ struct HomeView: View {
     }
     
     /// 미사용 쿠폰 리스트
-    func UnusedCouponListView() -> some View {
-        // TODO: - Hstack 리스트 구현
-        Rectangle()
-            .foregroundStyle(Color.mainViolet100)
+    func unusedCouponListView() -> some View {
+        
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .center, spacing: 8) {
+                ForEach(0..<5) {_ in
+                    BDMiniCoupon()
+                }
+            }
             .padding(.horizontal, 16)
-            .frame(minHeight: 270)
+        }
     }
 }
 

--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -16,9 +16,9 @@ struct HomeView: View {
     
     var body: some View {
         NavigationStack(path: $navPathManager.appPaths) {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(spacing: 16) {
-                    homeHeaderView(text: "자~ 로고들어갑니다")
+                    homeHeaderView(text: "자~ 로고들어갑니다 ^^")
                     createCouponCTAView()
                     couponShortcutView()
                     homeDivider()
@@ -167,18 +167,18 @@ struct HomeView: View {
     
     /// 미사용 쿠폰 리스트
     func unusedCouponListView() -> some View {
-        
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(alignment: .center, spacing: 8) {
-                ForEach(0..<5) {_ in
-                    BDMiniCoupon()
+                
+                // TODO: - 일정 갯수 이상 나오면, 더보기 카드(보관함)
+                ForEach(homeViewModel.mockCoupons) { coupon in
+                    BDMiniCoupon(coupon: coupon)
                 }
             }
             .padding(.horizontal, 16)
         }
     }
 }
-
 
 #Preview {
     HomeView()

--- a/BirtherDay/Presentation/Home/HomeViewModel.swift
+++ b/BirtherDay/Presentation/Home/HomeViewModel.swift
@@ -6,7 +6,163 @@
 //
 
 import Foundation
+import SwiftUI
 
-class HomeViewModel {
-    
+class HomeViewModel: ObservableObject {
+    @Published var mockCoupons: [Coupon] = [
+        Coupon(
+            couponId: "sample-id",
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "애슐리 디너\n1회 이용권",
+            letter: "축하해!",
+            imageList: [],
+            senderName: "주니",
+            expireDate: Date().addingTimeInterval(86400 * 60),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .orange,
+            couponTitle: "성수동 오마카세\n내가 쏜닿ㅎㅎ 가자~",
+            letter: "특별한 날에 딱이야!",
+            imageList: [],
+            senderName: "길지훈",
+            expireDate: Date().addingTimeInterval(86400 * 5),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🍷와인바 1병 함께 하기\n청담 와인루프탑",
+            letter: "분위기 있게 한 잔 어때?",
+            imageList: [],
+            senderName: "지민",
+            expireDate: Date().addingTimeInterval(86400 * 10),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🛍 코엑스 쇼핑 데이\n10만원 한도!",
+            letter: "갖고 싶은 거 골라!",
+            imageList: [],
+            senderName: "은지",
+            expireDate: Date().addingTimeInterval(86400 * 15),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🎬 용산 아이맥스\n팝콘 세트 포함",
+            letter: "보고 싶던 영화 같이 보자!",
+            imageList: [],
+            senderName: "찬우",
+            expireDate: Date().addingTimeInterval(86400 * 7),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .orange,
+            couponTitle: "🎮 PC방 5시간 이용권\n치킨도 내가 쏨",
+            letter: "게임하다 배고프면 치킨!",
+            imageList: [],
+            senderName: "태형",
+            expireDate: Date().addingTimeInterval(86400 * 2),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🍽 삼청동 브런치 투어\n카페 2곳 포함",
+            letter: "우리 힐링하자 ☕️",
+            imageList: [],
+            senderName: "소영",
+            expireDate: Date().addingTimeInterval(86400 * 20),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🏞 남산 야경 드라이브\n야식은 내가 책임질게",
+            letter: "도란도란 수다도 필수!",
+            imageList: [],
+            senderName: "현우",
+            expireDate: Date().addingTimeInterval(86400 * 8),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🧖‍♀️ 찜질방 데이\n찜질+계란+식혜 세트",
+            letter: "하루 푹 쉬자~",
+            imageList: [],
+            senderName: "다현",
+            expireDate: Date().addingTimeInterval(86400 * 6),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .orange,
+            couponTitle: "🎡 롯데월드 자유이용권\n1일 데이트권",
+            letter: "재밌게 놀자!!",
+            imageList: [],
+            senderName: "민재",
+            expireDate: Date().addingTimeInterval(86400 * 14),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        ),
+        Coupon(
+            couponId: UUID().uuidString,
+            sender: UUID(),
+            receiver: nil,
+            template: .blue,
+            couponTitle: "🌊 속초 당일치기 여행\n기름값 내가 낼게!",
+            letter: "바다 보러가자 🌴",
+            imageList: [],
+            senderName: "윤서",
+            expireDate: Date().addingTimeInterval(86400 * 12),
+            thumbnail: UIImage(),
+            isUsed: false,
+            createdDate: Date()
+        )
+    ]
 }

--- a/BirtherDay/Presentation/Home/HomeViewModel.swift
+++ b/BirtherDay/Presentation/Home/HomeViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  HomeViewModel.swift
+//  BirtherDay
+//
+//  Created by 길지훈 on 6/3/25.
+//
+
+import Foundation
+
+class HomeViewModel {
+    
+}

--- a/BirtherDay/Presentation/Home/HomeViewModel.swift
+++ b/BirtherDay/Presentation/Home/HomeViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+//@Observable
 class HomeViewModel: ObservableObject {
     @Published var mockCoupons: [Coupon] = [
         Coupon(

--- a/BirtherDay/Presentation/MyCoupons/Template/CouponTemplateType.swift
+++ b/BirtherDay/Presentation/MyCoupons/Template/CouponTemplateType.swift
@@ -12,6 +12,7 @@ enum CouponTemplate: String, Codable {
     case blue
     case orange
     
+    // BDCoupon
     /// 배경 색상
     var basicColor: Color {
         switch self {
@@ -71,6 +72,38 @@ enum CouponTemplate: String, Codable {
             return Color(hex: "F6F2FF")
         case .orange:
             return Color(hex: "FFF4F4")
+        }
+    }
+    
+    // BDMiniCoupon
+    var miniCouponBackgroundColor: Color {
+        switch self {
+        
+        case .blue:
+            return Color(hex: "E5ECFF")
+        case .orange:
+            return Color.mainViolet100
+        }
+    }
+    
+    var miniCouponImage: SwiftUI.Image {
+        switch self {
+        case .blue:
+            return Image("Card2Box")
+        case .orange:
+            return Image("Card1Box")
+        }
+    }
+    
+    // TODO: - 대응 가능성 있음.
+    /// mini 점선 색상
+    var miniDashLineColor: Color {
+        switch self {
+        case .blue:
+            return Color(hex: "B6D6FF")
+            
+        case .orange:
+            return Color(hex: "FFC68F")
         }
     }
 }


### PR DESCRIPTION
## 👀 **작업한 내용, 스크린샷**
<!-- 작업한 내용과 스크린샷을 적어주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2025-06-04 at 01 00 03](https://github.com/user-attachments/assets/61fe16fc-4832-44d6-839f-d2bbb8d2d1ed)

### 1. 홈뷰의 레이아웃과, 컴포넌트들을 배치했고 데스티네이션을 연결했습니다.
### 2.  HomeViewModel을 추가했습니다.
```swift
class HomeViewModel: ObservableObject {
    @Published var mockCoupons: [Coupon] = [ ... ]
}
```
현재는, mock 데이터만 넣었고
후에, 조회 api가 완료되면 실제 데이터를 조회하는 로직이 들어갈 예정입니다.

### 3. BDMiniCoupon
<img width="260" alt="스크린샷 2025-06-04 01 05 32" src="https://github.com/user-attachments/assets/95a760e1-6a4e-4e80-a5c8-3aa2d46ea2bd" />

홈뷰에서 **미사용 쿠폰** 조회용 미니쿠폰 컴포넌트를 만들고 **Common/Components**로 분리했습니다.

## 💌 이후 TODO
<!-- 참고할 사항이 있다면 적어주세요. -->
- Logo, Image 에셋 추가 (현재 검은 rectangle 영역)
- 미사용 쿠폰 리스트
```swift
    /// 미사용 쿠폰 리스트
    func unusedCouponListView() -> some View {
        ScrollView(.horizontal, showsIndicators: false) {
            HStack(alignment: .center, spacing: 8) {
                
                // TODO: - 일정 갯수 이상 나오면, 더보기 카드(보관함)
                ForEach(homeViewModel.mockCoupons) { coupon in
                    BDMiniCoupon(coupon: coupon)
                }
            }
            .padding(.horizontal, 16)
        }
    }
```
이후 **보관함**과 **보관함에서 쿠폰 상세 페이지** 구현 후, 
 (1). CardViewList로 변경 -> 각 카드뷰 선택 액션 구현
 (2). 일정 갯수 이상 나오면, 더보기 카드(보관함)
 
 ---

화이팅임다~!
