### PR TITLE
[Fix] 홈 애니메이션 - dotLottie 메모리 leaking

### DIFF
--- a/BirtherDay/Presentation/Home/HomeView.swift
+++ b/BirtherDay/Presentation/Home/HomeView.swift
@@ -14,6 +14,8 @@ struct HomeView: View {
     @State private var couponType: CouponType = .received
     @StateObject private var homeViewModel = HomeViewModel()
     @StateObject private var myCouponViewModel = MyCouponViewModel()
+    @State private var animation = DotLottieAnimation(fileName: "giftbox", config: AnimationConfig(autoplay: true, loop: true, useFrameInterpolation: false)
+    )
     
     var body: some View {
         NavigationStack(path: $navPathManager.appPaths) {
@@ -58,12 +60,10 @@ struct HomeView: View {
                     .font(.b2)
                     .multilineTextAlignment(.center)
                 
-                // TODO: - Image 연결
-                DotLottieAnimation(fileName: "giftbox", config: AnimationConfig(autoplay: true, loop: true)
-                )
-                .view()
-                .frame(minWidth: 150, minHeight: 150)
-                .padding(-16)
+                animation
+                    .view()
+                    .frame(minWidth: 150, minHeight: 150)
+                    .padding(-16)
                 
                 Button {
                     navPathManager.pushCreatePath(.selectTemplate)


### PR DESCRIPTION
## 👀 **작업한 내용, 스크린샷**
![image](https://github.com/user-attachments/assets/1d3b1475-7cfb-4f58-9201-4a03cbbbe189)


## 💌 참고 사항

```swift
    @State private var animation = DotLottieAnimation(fileName: "giftbox", config: AnimationConfig(autoplay: true, loop: true, useFrameInterpolation: false)
    )
```

공식문서대로 기존에는 animation 뷰를 바로 뿌렸는데.
메모리 해제가 안되는 현상이 있습니다. 
**(이건 사실 라이브러리 자체적으로 해줘야하는거아닐까요?)**

그래서 저희 홈 화면의 애니메이션 같은 경우, 정적으로만 필요하기 때문에
뷰 인스턴스를 한 번만 생성하여 재사용하게 수정했습니다.

실제로 다른 유저들도 똑같은 현상을 겪고, 위 코드처럼 @State로 직접 관리하는 방식으로 해결하고 있습니다!
